### PR TITLE
Include the "module" style by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "import-sort-config": "2.4.0",
         "import-sort-parser-babylon": "2.3.0",
         "import-sort-parser-typescript": "2.2.1",
-        "import-sort-style-eslint": "2.4.0"
+        "import-sort-style-eslint": "2.4.0",
+        "import-sort-style-module": "2.4.0"
     }
 }


### PR DESCRIPTION
To allow simple configuration using the package.json to switch between "eslint" and "module" styles without having to install "import-sort-style-module" into every project.

Example from https://github.com/renke/import-sort/blob/master/README.md
```
"importSort": {
  ".js, .jsx, .es6, .es": {
    "parser": "babylon",
    "style": "eslint"
  },
  ".ts, .tsx": {
    "parser": "typescript",
    "style": "module"
  }
}
```